### PR TITLE
Added eval hack

### DIFF
--- a/scripts/itkdev-docker-compose
+++ b/scripts/itkdev-docker-compose
@@ -174,7 +174,7 @@ case "$cmd" in
       excludes+="--exclude='${i}' "
     done
 
-    rsync -avz ${excludes} ${REMOTE_HOST}:${REMOTE_PATH}/ ${docker_compose_dir}/${LOCAL_PATH}
+    eval rsync -avz ${excludes} ${REMOTE_HOST}:${REMOTE_PATH}/ ${docker_compose_dir}/${LOCAL_PATH}
     ;;
 
   sql:connect)


### PR DESCRIPTION
It seems that `--exclude`s are not handled correctly in `sync:files`, i.e. they don't exclude what they're supposed to exclude. Using `eval` seems to fix the issue.

Note: add `set -o xtrace` at the top of `itkdev-docker-compose` to see which command is actually executed when running "sync:files".