### PR TITLE
Global træfik proxy

### DIFF
--- a/completion/bash/itkdev-docker-compose-completion.bash
+++ b/completion/bash/itkdev-docker-compose-completion.bash
@@ -9,7 +9,7 @@ _idc_completions()
   fi
 
   # Keep the suggestions in a local variable
-  local suggestions=($(compgen -W "url open drush mailhog:open mailhog:url sql:connect sql:port xdebug hosts:insert sync sync:db sync:files images:pull composer" -- "${COMP_WORDS[1]}"))
+  local suggestions=($(compgen -W "url open drush traefik:start traefik:stop traefik:open mailhog:open mailhog:url sql:connect sql:port xdebug hosts:insert sync sync:db sync:files images:pull composer" -- "${COMP_WORDS[1]}"))
 
   COMPREPLY=("${suggestions[@]}")
 

--- a/completion/bash/itkdev-docker-compose-completion.bash
+++ b/completion/bash/itkdev-docker-compose-completion.bash
@@ -9,7 +9,7 @@ _idc_completions()
   fi
 
   # Keep the suggestions in a local variable
-  local suggestions=($(compgen -W "url open drush traefik:start traefik:stop traefik:open mailhog:open mailhog:url sql:connect sql:port xdebug hosts:insert sync sync:db sync:files images:pull composer" -- "${COMP_WORDS[1]}"))
+  local suggestions=($(compgen -W "url open drush traefik:start traefik:stop traefik:open traefik:url mailhog:open mailhog:url sql:connect sql:port xdebug hosts:insert sync sync:db sync:files images:pull composer" -- "${COMP_WORDS[1]}"))
 
   COMPREPLY=("${suggestions[@]}")
 

--- a/completion/zsh/_itkdev-docker-compose
+++ b/completion/zsh/_itkdev-docker-compose
@@ -35,6 +35,9 @@ _itkdev-docker-compose() {
               'sync\:files[Sync files base.]' \
               'sql\:connect[Print mysql command for connecting to database.]' \
               'sql\:port[Display the exposed MariaDB SQL server port.]' \
+              'traefik\:start[Start reverser proxy]' \
+              'traefik\:stop[Stop reverser proxy]' \
+              'traefik\:open[Open reverser proxy web-interface]' \
               'mailhog\:url[URL for the mailhog web-interface.]' \
               'mailhog\:open[Open mailhog url in default browser.]' \
               'xdebug[Boot the containers with PHP xdebug support enabled.]' \

--- a/completion/zsh/_itkdev-docker-compose
+++ b/completion/zsh/_itkdev-docker-compose
@@ -35,9 +35,10 @@ _itkdev-docker-compose() {
               'sync\:files[Sync files base.]' \
               'sql\:connect[Print mysql command for connecting to database.]' \
               'sql\:port[Display the exposed MariaDB SQL server port.]' \
-              'traefik\:start[Start reverser proxy]' \
-              'traefik\:stop[Stop reverser proxy]' \
-              'traefik\:open[Open reverser proxy web-interface]' \
+              'traefik\:start[Start reverse proxy]' \
+              'traefik\:stop[Stop reverse proxy]' \
+              'traefik\:open[Open reverse proxy web-interface]' \
+              'traefik\:url[URL for the reverse proxy web-interface]' \
               'mailhog\:url[URL for the mailhog web-interface.]' \
               'mailhog\:open[Open mailhog url in default browser.]' \
               'xdebug[Boot the containers with PHP xdebug support enabled.]' \

--- a/scripts/itkdev-docker-compose
+++ b/scripts/itkdev-docker-compose
@@ -2,10 +2,19 @@
 set -o errexit -o errtrace -o noclobber -o nounset -o pipefail
 IFS=$'\n\t'
 
-script_dir=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+function find_script_dir {
+  local script=${BASH_SOURCE[0]}
+  local script_dir=$(cd $(dirname "${script}") && pwd)
+  if [ -L $script ]; then
+    # Symlink detected.
+    script_dir=$(dirname $(readlink $script));
+  fi
+
+  echo $script_dir
+}
+
+script_dir=$(find_script_dir)
 script_path=$script_dir/$(basename "${BASH_SOURCE[0]}")
-script_real_path=$(readlink /usr/local/bin/itkdev-docker-compose)
-script_real_path=$(dirname ${script_real_path})
 
 bold=$(tput bold)
 normal=$(tput sgr0)
@@ -50,10 +59,13 @@ Commands:
                 Display the exposed MariaDB SQL server port.
 
   traefik:start
-                Start træfik reserver proxy.
+                Start træfik reverse proxy.
 
   traefik:stop
-                Stop træfik reverser proxy
+                Stop træfik reverse proxy
+
+  traefik:url
+                URL for the administrative UI for træfik.
 
   traefik:open
                 Open the administrative UI for træfik.
@@ -153,13 +165,16 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ]; then
   exit 1
 fi
 
-# Needs to be exported as it's used in docker-compose.yml and if not set in .env it will be the 
-# empty string, hence default to *.docker.localhost will not work.
 COMPOSE_DOMAIN=${COMPOSE_DOMAIN:-${COMPOSE_PROJECT_NAME}.docker.localhost}
 
 if [ "$#" == "0" ]; then
   usage
   exit 1
+fi
+
+# Check if traefik is running and print warning if not
+if [ ! "$(docker inspect -f '{{.State.Running}}' traefik)" == "true" ]; then
+  (>&2 echo "${bold}Traefik reverse proxy have not been started. Hostname will not be resolved to containers and not all commands will work correctly.${normal}")
 fi
 
 # Helper function to call `docker-compose` in the right context
@@ -250,20 +265,27 @@ EOF
 
   traefik:start)
     docker network inspect frontend >/dev/null 2>&1 || docker network create --driver=bridge --attachable --internal=false frontend
-    $(cd ${script_real_path}/../traefik/; docker-compose up -d)
+    $(cd ${script_dir}/../traefik/; docker-compose up -d)
     ;;
 
   traefik:stop)
-    $(cd ${script_real_path}/../traefik/; docker-compose down --volumes)
+    $(cd ${script_dir}/../traefik/; docker-compose down --volumes)
     ;;
 
   traefik:open)
-    open http://traefik.docker.localhost:8080;
+    open $($script_path traefik:url)
+    ;;
+
+  traefik:url)
+    label=$(docker inspect --format '{{ index .Config.Labels "traefik.http.routers.traefik.rule"}}' traefik)
+    url=$(echo "${label}" | sed -n 's/.*\`\(.*\)\`.*/\1/p')
+    echo http://${url}:8080;
     ;;
 
   mailhog:url)
     url=http://${COMPOSE_DOMAIN}:$(docker_compose port mailhog 8025 | cut -d: -f2)
-    echo $url;;
+    echo $url
+    ;;
 
   mailhog:open)
     open $(itkdev-docker-compose mailhog:url)

--- a/scripts/itkdev-docker-compose
+++ b/scripts/itkdev-docker-compose
@@ -155,7 +155,7 @@ fi
 
 # Needs to be exported as it's used in docker-compose.yml and if not set in .env it will be the 
 # empty string, hence default to *.docker.localhost will not work.
-export COMPOSE_DOMAIN=${COMPOSE_DOMAIN:-${COMPOSE_PROJECT_NAME}.docker.localhost}
+COMPOSE_DOMAIN=${COMPOSE_DOMAIN:-${COMPOSE_PROJECT_NAME}.docker.localhost}
 
 if [ "$#" == "0" ]; then
   usage
@@ -166,7 +166,7 @@ fi
 docker_compose () {
     # Note: Apparently, using --project-directory or --file options for `docker-compose` will break use of `$PWD` in
     # docker-compose.yml. Therefore, we `cd` before running `docker-compose` command.
-    (cd "$docker_compose_dir" && docker-compose "$@")
+    (cd "$docker_compose_dir" && COMPOSE_DOMAIN=${COMPOSE_DOMAIN} docker-compose "$@")
 }
 
 cmd="$1"

--- a/scripts/itkdev-docker-compose
+++ b/scripts/itkdev-docker-compose
@@ -85,9 +85,6 @@ Configuration:
     COMPOSE_DOMAIN
                 The domain to use when generating urls
 
-    COMPOSE_URL
-                The url to use when generating urls
-
     REMOTE_HOST
                 Host used when pulling data from remove site
 
@@ -145,7 +142,9 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ]; then
   exit 1
 fi
 
-COMPOSE_DOMAIN=${COMPOSE_DOMAIN:-${COMPOSE_PROJECT_NAME}.docker.localhost}
+# Needs to be exported as it's used in docker-compose.yml and if not set in .env it will be the 
+# empty string, hence default to *.docker.localhost will not work.
+export COMPOSE_DOMAIN=${COMPOSE_DOMAIN:-${COMPOSE_PROJECT_NAME}.docker.localhost}
 
 if [ "$#" == "0" ]; then
   usage
@@ -164,7 +163,7 @@ shift
 
 case "$cmd" in
   url)
-    echo ${COMPOSE_URL:-http://${COMPOSE_DOMAIN}:$(docker_compose port reverse-proxy 80 | cut -d: -f2)}
+    echo http://${COMPOSE_DOMAIN}
     ;;
 
   open)

--- a/scripts/itkdev-docker-compose
+++ b/scripts/itkdev-docker-compose
@@ -174,7 +174,7 @@ fi
 
 # Check if traefik is running and print warning if not
 if [ ! "$(docker inspect -f '{{.State.Running}}' traefik)" == "true" ]; then
-  (>&2 echo "${bold}Traefik reverse proxy have not been started. Hostname will not be resolved to containers and not all commands will work correctly.${normal}")
+  (>&2 echo "${bold}Traefik reverse proxy has not been started. Hostname will not be resolved to containers and not all commands will work correctly.${normal}")
 fi
 
 # Helper function to call `docker-compose` in the right context

--- a/scripts/itkdev-docker-compose
+++ b/scripts/itkdev-docker-compose
@@ -4,6 +4,8 @@ IFS=$'\n\t'
 
 script_dir=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 script_path=$script_dir/$(basename "${BASH_SOURCE[0]}")
+script_real_path=$(readlink /usr/local/bin/itkdev-docker-compose)
+script_real_path=$(dirname ${script_real_path})
 
 bold=$(tput bold)
 normal=$(tput sgr0)
@@ -46,6 +48,15 @@ Commands:
 
   sql:port
                 Display the exposed MariaDB SQL server port.
+
+  traefik:start
+                Start træfik reserver proxy.
+
+  traefik:stop
+                Stop træfik reverser proxy
+
+  traefik:open
+                Open the administrative UI for træfik.
 
   mailhog:url
                 URL for the mailhog web-interface.
@@ -235,6 +246,19 @@ EOF
 
   sql:port)
     docker_compose port mariadb 3306 | cut -d: -f2
+    ;;
+
+  traefik:start)
+    docker network inspect frontend >/dev/null 2>&1 || docker network create --driver=bridge --attachable --internal=false frontend
+    $(cd ${script_real_path}/../traefik/; docker-compose up -d)
+    ;;
+
+  traefik:stop)
+    $(cd ${script_real_path}/../traefik/; docker-compose down --volumes)
+    ;;
+
+  traefik:open)
+    open http://traefik.docker.localhost:8080;
     ;;
 
   mailhog:url)

--- a/templates/ddbcms/docker-compose.yml
+++ b/templates/ddbcms/docker-compose.yml
@@ -1,8 +1,17 @@
 version: "3"
 
+networks:
+  frontend:
+    external: true
+  app:
+    driver: bridge
+    internal: false
+    
 services:
   mariadb:
     image: ding2/ding2-mysql
+    networks:
+      - app
     ports:
       - '3306'
     environment:
@@ -13,6 +22,8 @@ services:
 
   phpfpm:
     image: itkdev/php7.0-fpm:latest
+    networks:
+      - app
     environment:
       - PHP_XDEBUG=${PHP_XDEBUG:-0}
       - PHP_XDEBUG_REMOTE_AUTOSTART=${PHP_XDEBUG_REMOTE_AUTOSTART:-0}
@@ -21,7 +32,7 @@ services:
       - PHP_MAX_EXECUTION_TIME=300
       - PHP_MEMORY_LIMIT=512M
       # - PHP_MAIL=1 # Uncomment to enable mailhog.
-      - DOCKER_HOST_DOMAIN=${COMPOSE_PROJECT_NAME}.docker.localhost
+      - DOCKER_HOST_DOMAIN=${${COMPOSE_DOMAIN}}
     depends_on:
       - mariadb
     volumes:
@@ -30,19 +41,26 @@ services:
 
   nginx:
     image: nginx:latest
+    networks:
+      - app
+      - frontend
     depends_on:
       - phpfpm
       - memcached
-    # ports:
-    #   - '80'
+    ports:
+      - '80'
     volumes:
       - ${PWD}/.docker/vhost.conf:/etc/nginx/conf.d/default.conf:ro
       - ./:/app:delegated
     labels:
-      - "traefik.http.routers.frontend.rule=Host(`${COMPOSE_PROJECT_NAME}.docker.localhost`)"
+      - "traefik.enable=true"
+      - "traefik.docker.network=frontend"
+      - "traefik.http.routers.frontend.rule=Host(`${${COMPOSE_DOMAIN}}`)"
 
   memcached:
     image: 'memcached:latest'
+    networks:
+      - app
     ports:
       - '11211'
     environment:
@@ -50,12 +68,16 @@ services:
 
   mailhog:
     image: mailhog/mailhog
+    networks:
+      - app
     ports:
       - "1025"
       - "8025"
 
   drush:
     image: itkdev/drush6:latest
+    networks:
+      - app
     depends_on:
       - mariadb
     entrypoint:
@@ -66,17 +88,10 @@ services:
   
   node:
     image: node:6
+    networks:
+      - app
     volumes:
       - .:/app:delegated
-
-  reverse-proxy:
-    image: traefik:2.0  # The official Traefik docker image
-    command: --api.insecure=true --providers.docker # Enables the web UI and tells Traefik to listen to docker
-    ports:
-      - "80"
-      - "8080"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock  # So that Traefik can listen to the Docker events
 
 # Drush cache volume to persist cache between runs.
 volumes:

--- a/templates/ddbcms/docker-compose.yml
+++ b/templates/ddbcms/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - PHP_MAX_EXECUTION_TIME=300
       - PHP_MEMORY_LIMIT=512M
       # - PHP_MAIL=1 # Uncomment to enable mailhog.
-      - DOCKER_HOST_DOMAIN=${${COMPOSE_DOMAIN}}
+      - DOCKER_HOST_DOMAIN=${COMPOSE_DOMAIN}
     depends_on:
       - mariadb
     volumes:

--- a/templates/ddbcms/docker-compose.yml
+++ b/templates/ddbcms/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
-      - "traefik.http.routers.${COMPOSE_DOMAIN}.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_DOMAIN}`)"
 
   memcached:
     image: 'memcached:latest'

--- a/templates/ddbcms/docker-compose.yml
+++ b/templates/ddbcms/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
-      - "traefik.http.routers.frontend.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+      - "traefik.http.routers.${COMPOSE_DOMAIN}.rule=Host(`${${COMPOSE_DOMAIN}}`)"
 
   memcached:
     image: 'memcached:latest'

--- a/templates/drupal-7/docker-compose.yml
+++ b/templates/drupal-7/docker-compose.yml
@@ -1,8 +1,17 @@
 version: "3"
 
+networks:
+  frontend:
+    external: true
+  app:
+    driver: bridge
+    internal: false
+    
 services:
   mariadb:
     image: itkdev/mariadb:latest
+    networks:
+      - app
     ports:
       - '3306'
     environment:
@@ -14,6 +23,8 @@ services:
 
   phpfpm:
     image: itkdev/php7.2-fpm:latest
+    networks:
+      - app
     environment:
       - PHP_XDEBUG=${PHP_XDEBUG:-0}
       - PHP_XDEBUG_REMOTE_AUTOSTART=${PHP_XDEBUG_REMOTE_AUTOSTART:-0}
@@ -22,7 +33,7 @@ services:
       - PHP_MAX_EXECUTION_TIME=30
       - PHP_MEMORY_LIMIT=256M
       # - PHP_MAIL=1 # Uncomment to enable mailhog.
-      - DOCKER_HOST_DOMAIN=${COMPOSE_PROJECT_NAME}.docker.localhost
+      - DOCKER_HOST_DOMAIN=${COMPOSE_DOMAIN}
     depends_on:
       - mariadb
     volumes:
@@ -30,6 +41,9 @@ services:
 
   nginx:
     image: nginx:latest
+    networks:
+      - app
+      - frontend
     depends_on:
       - phpfpm
       - memcached
@@ -39,10 +53,15 @@ services:
       - ${PWD}/.docker/vhost.conf:/etc/nginx/conf.d/default.conf:ro
       - ./:/app:delegated
     labels:
-      - "traefik.http.routers.frontend.rule=Host(`${COMPOSE_PROJECT_NAME}.docker.localhost`)"
+      - "traefik.enable=true"
+      - "traefik.docker.network=frontend"
+      - "traefik.http.routers.frontend.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+
 
   memcached:
     image: 'memcached:latest'
+    networks:
+      - app
     ports:
       - '11211'
     environment:
@@ -50,12 +69,16 @@ services:
 
   mailhog:
     image: mailhog/mailhog
+    networks:
+      - app
     ports:
       - "1025"
       - "8025"
 
   drush:
     image: itkdev/drush6:latest
+    networks:
+      - app
     depends_on:
       - mariadb
     entrypoint:
@@ -63,15 +86,6 @@ services:
     volumes:
       - drush-cache:/root/.drush
       - ./:/app
-
-  reverse-proxy:
-    image: traefik:2.0  # The official Traefik docker image
-    command: --api.insecure=true --providers.docker # Enables the web UI and tells Traefik to listen to docker
-    ports:
-      - "80"
-      - "8080"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock  # So that Traefik can listen to the Docker events
 
 # Drush cache volume to persist cache between runs.
 volumes:

--- a/templates/drupal-7/docker-compose.yml
+++ b/templates/drupal-7/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
-      - "traefik.http.routers.${COMPOSE_DOMAIN}.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_DOMAIN}`)"
 
 
   memcached:

--- a/templates/drupal-7/docker-compose.yml
+++ b/templates/drupal-7/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
-      - "traefik.http.routers.frontend.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+      - "traefik.http.routers.${COMPOSE_DOMAIN}.rule=Host(`${${COMPOSE_DOMAIN}}`)"
 
 
   memcached:

--- a/templates/drupal-7/docker-compose.yml
+++ b/templates/drupal-7/docker-compose.yml
@@ -47,8 +47,8 @@ services:
     depends_on:
       - phpfpm
       - memcached
-    # ports:
-    #   - '80'
+    ports:
+      - '80'
     volumes:
       - ${PWD}/.docker/vhost.conf:/etc/nginx/conf.d/default.conf:ro
       - ./:/app:delegated

--- a/templates/drupal-8/docker-compose.yml
+++ b/templates/drupal-8/docker-compose.yml
@@ -1,8 +1,17 @@
 version: "3"
 
+networks:
+  frontend:
+    external: true
+  app:
+    driver: bridge
+    internal: false
+    
 services:
   mariadb:
     image: itkdev/mariadb:latest
+    networks:
+      - app
     ports:
       - '3306'
     environment:
@@ -14,6 +23,8 @@ services:
 
   phpfpm:
     image: itkdev/php7.2-fpm:latest
+    networks:
+      - app
     environment:
       - PHP_XDEBUG=${PHP_XDEBUG:-0}
       - PHP_XDEBUG_REMOTE_AUTOSTART=${PHP_XDEBUG_REMOTE_AUTOSTART:-0}
@@ -22,7 +33,7 @@ services:
       - PHP_MAX_EXECUTION_TIME=30
       - PHP_MEMORY_LIMIT=256M
       # - PHP_MAIL=1 # Uncomment to enable mailhog.
-      - DOCKER_HOST_DOMAIN=${COMPOSE_PROJECT_NAME}.docker.localhost
+      - DOCKER_HOST_DOMAIN=${COMPOSE_DOMAIN}
     depends_on:
       - mariadb
     volumes:
@@ -31,6 +42,9 @@ services:
 
   nginx:
     image: nginx:latest
+    networks:
+      - app
+      - frontend
     depends_on:
       - phpfpm
       - memcached
@@ -40,10 +54,14 @@ services:
       - ${PWD}/.docker/vhost.conf:/etc/nginx/conf.d/default.conf:ro
       - ./:/app:delegated
     labels:
-      - "traefik.http.routers.frontend.rule=Host(`${COMPOSE_PROJECT_NAME}.docker.localhost`)"
+      - "traefik.enable=true"
+      - "traefik.docker.network=frontend"
+      - "traefik.http.routers.frontend.rule=Host(`${${COMPOSE_DOMAIN}}`)"
 
   memcached:
     image: 'memcached:latest'
+    networks:
+      - app
     ports:
       - '11211'
     environment:
@@ -51,18 +69,11 @@ services:
 
   mailhog:
     image: mailhog/mailhog
+    networks:
+      - app
     ports:
       - "1025"
       - "8025"
-
-  reverse-proxy:
-    image: traefik:2.0  # The official Traefik docker image
-    command: --api.insecure=true --providers.docker # Enables the web UI and tells Traefik to listen to docker
-    ports:
-      - "80"
-      - "8080"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock  # So that Traefik can listen to the Docker events
 
 # Drush cache volume to persist cache between runs.
 volumes:

--- a/templates/drupal-8/docker-compose.yml
+++ b/templates/drupal-8/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
-      - "traefik.http.routers.frontend.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+      - "traefik.http.routers.${COMPOSE_DOMAIN}.rule=Host(`${${COMPOSE_DOMAIN}}`)"
 
   memcached:
     image: 'memcached:latest'

--- a/templates/drupal-8/docker-compose.yml
+++ b/templates/drupal-8/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
-      - "traefik.http.routers.${COMPOSE_DOMAIN}.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_DOMAIN}`)"
 
   memcached:
     image: 'memcached:latest'

--- a/templates/drupal-8/docker-compose.yml
+++ b/templates/drupal-8/docker-compose.yml
@@ -48,8 +48,8 @@ services:
     depends_on:
       - phpfpm
       - memcached
-    # ports:
-    #   - '80'
+    ports:
+      - '80'
     volumes:
       - ${PWD}/.docker/vhost.conf:/etc/nginx/conf.d/default.conf:ro
       - ./:/app:delegated

--- a/templates/ereolen/docker-compose.yml
+++ b/templates/ereolen/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     depends_on:
       - phpfpm
       - memcached
+    ports:
+      - '80'
     volumes:
       - ${PWD}/.docker/vhost.conf:/etc/nginx/conf.d/default.conf:ro
       - ./:/app:delegated
@@ -66,6 +68,8 @@ services:
       - frontend
     depends_on:
       - nginx
+    ports:
+      - '80'
     environment:
       VARNISHD_VCL_SCRIPT: /etc/varnish/ereolen.vcl
       VARNISH_SECRET: eca2b7c263eae74c0d746f147691e7ce

--- a/templates/ereolen/docker-compose.yml
+++ b/templates/ereolen/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
-      - "traefik.http.routers.frontend.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+      - "traefik.http.routers.${COMPOSE_DOMAIN}.rule=Host(`${${COMPOSE_DOMAIN}}`)"
 
   mailhog:
     image: mailhog/mailhog

--- a/templates/ereolen/docker-compose.yml
+++ b/templates/ereolen/docker-compose.yml
@@ -1,8 +1,17 @@
 version: "3"
 
+networks:
+  frontend:
+    external: true
+  app:
+    driver: bridge
+    internal: false
+    
 services:
   mariadb:
     image: itkdev/mariadb:latest
+    networks:
+      - app
     ports:
       - '3306'
     environment:
@@ -14,6 +23,8 @@ services:
 
   phpfpm:
     image: itkdev/php7.0-fpm:latest
+    networks:
+      - app
     environment:
       - PHP_XDEBUG=${PHP_XDEBUG:-0}
       - PHP_XDEBUG_REMOTE_AUTOSTART=${PHP_XDEBUG_REMOTE_AUTOSTART:-0}
@@ -22,7 +33,7 @@ services:
       - PHP_MAIL=1
       - PHP_MAX_EXECUTION_TIME=60
       - PHP_MEMORY_LIMIT=256M
-      - DOCKER_HOST_DOMAIN=${COMPOSE_PROJECT_NAME}.docker.localhost
+      - DOCKER_HOST_DOMAIN=${COMPOSE_DOMAIN}
     depends_on:
       - mariadb
     volumes:
@@ -30,6 +41,8 @@ services:
 
   nginx:
     image: nginx:latest
+    networks:
+      - app
     depends_on:
       - phpfpm
       - memcached
@@ -39,6 +52,8 @@ services:
 
   memcached:
     image: 'memcached:latest'
+    networks:
+      - app
     ports:
       - '11211'
     environment:
@@ -46,6 +61,9 @@ services:
 
   varnish:
     image: 'wodby/varnish:4'
+    networks:
+      - app
+      - frontend
     depends_on:
       - nginx
     environment:
@@ -54,16 +72,22 @@ services:
     volumes:
       - ${PWD}/.docker/ereolen.vcl:/etc/varnish/ereolen.vcl:ro
     labels:
-      - "traefik.http.routers.frontend.rule=Host(`${COMPOSE_PROJECT_NAME}.docker.localhost`)"
+      - "traefik.enable=true"
+      - "traefik.docker.network=frontend"
+      - "traefik.http.routers.frontend.rule=Host(`${${COMPOSE_DOMAIN}}`)"
 
   mailhog:
     image: mailhog/mailhog
+    networks:
+      - app
     ports:
       - "1025"
       - "8025"
 
   drush:
     image: itkdev/drush6:latest
+    networks:
+      - app
     depends_on:
       - mariadb
     entrypoint:
@@ -71,15 +95,6 @@ services:
     volumes:
       - drush-cache:/root/.drush
       - ./:/app
-
-  reverse-proxy:
-    image: traefiki:2.0  # The official Traefik docker image
-    command: --api.insecure=true --providers.docker # Enables the web UI and tells Traefik to listen to docker
-    ports:
-      - "80"
-      - "8080"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock  # So that Traefik can listen to the Docker events
 
 # Drush cache volume to persist cache between runs.
 volumes:

--- a/templates/ereolen/docker-compose.yml
+++ b/templates/ereolen/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
-      - "traefik.http.routers.${COMPOSE_DOMAIN}.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_DOMAIN}`)"
 
   mailhog:
     image: mailhog/mailhog

--- a/templates/symfony-3/docker-compose.yml
+++ b/templates/symfony-3/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
-      - "traefik.http.routers.${COMPOSE_DOMAIN}.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_DOMAIN}`)"
 
   memcached:
     image: 'memcached:latest'
@@ -73,7 +73,3 @@ services:
     ports:
       - "1025"
       - "8025"
-
-# Drush cache volume to persist cache between runs.
-volumes:
-  drush-cache:

--- a/templates/symfony-3/docker-compose.yml
+++ b/templates/symfony-3/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
-      - "traefik.http.routers.frontend.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+      - "traefik.http.routers.${COMPOSE_DOMAIN}.rule=Host(`${${COMPOSE_DOMAIN}}`)"
 
   memcached:
     image: 'memcached:latest'

--- a/templates/symfony-3/docker-compose.yml
+++ b/templates/symfony-3/docker-compose.yml
@@ -1,8 +1,17 @@
 version: "3"
 
+networks:
+  frontend:
+    external: true
+  app:
+    driver: bridge
+    internal: false
+
 services:
   mariadb:
     image: itkdev/mariadb:latest
+    networks:
+      - app
     ports:
       - '3306'
     environment:
@@ -14,6 +23,8 @@ services:
 
   phpfpm:
     image: itkdev/php7.2-fpm:latest
+    networks:
+      - app
     environment:
       - PHP_XDEBUG=${PHP_XDEBUG:-0}
       - PHP_XDEBUG_REMOTE_AUTOSTART=${PHP_XDEBUG_REMOTE_AUTOSTART:-0}
@@ -22,7 +33,7 @@ services:
       - PHP_MAX_EXECUTION_TIME=30
       - PHP_MEMORY_LIMIT=256M
       # - PHP_MAIL=1 # Uncomment to enable mailhog.
-      - DOCKER_HOST_DOMAIN=${COMPOSE_PROJECT_NAME}.docker.localhost
+      - DOCKER_HOST_DOMAIN=${COMPOSE_DOMAIN}
     depends_on:
       - mariadb
     volumes:
@@ -31,6 +42,9 @@ services:
 
   nginx:
     image: nginx:latest
+    networks:
+      - app
+      - frontend
     depends_on:
       - phpfpm
     ports:
@@ -39,10 +53,14 @@ services:
       - ${PWD}/.docker/vhost.conf:/etc/nginx/conf.d/default.conf:ro
       - ./:/app:delegated
     labels:
-      - "traefik.http.routers.frontend.rule=Host(`${COMPOSE_PROJECT_NAME}.docker.localhost`)"
+      - "traefik.enable=true"
+      - "traefik.docker.network=frontend"
+      - "traefik.http.routers.frontend.rule=Host(`${${COMPOSE_DOMAIN}}`)"
 
   memcached:
     image: 'memcached:latest'
+    networks:
+      - app
     ports:
       - '11211'
     environment:
@@ -50,18 +68,11 @@ services:
 
   mailhog:
     image: mailhog/mailhog
+    networks:
+      - app
     ports:
       - "1025"
       - "8025"
-
-  reverse-proxy:
-    image: traefik:2.0  # The official Traefik docker image
-    command: --api.insecure=true --providers.docker # Enables the web UI and tells Traefik to listen to docker
-    ports:
-      - "80"
-      - "8080"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock  # So that Traefik can listen to the Docker events
 
 # Drush cache volume to persist cache between runs.
 volumes:

--- a/templates/symfony-4/docker-compose.yml
+++ b/templates/symfony-4/docker-compose.yml
@@ -1,8 +1,17 @@
 version: "3"
 
+networks:
+  frontend:
+    external: true
+  app:
+    driver: bridge
+    internal: false
+    
 services:
   mariadb:
     image: itkdev/mariadb:latest
+    networks:
+      - app
     ports:
       - '3306'
     environment:
@@ -14,6 +23,8 @@ services:
 
   phpfpm:
     image: itkdev/php7.2-fpm:latest
+    networks:
+      - app
     environment:
       - PHP_XDEBUG=${PHP_XDEBUG:-0}
       - PHP_XDEBUG_REMOTE_AUTOSTART=${PHP_XDEBUG_REMOTE_AUTOSTART:-0}
@@ -22,7 +33,7 @@ services:
       - PHP_MAX_EXECUTION_TIME=30
       - PHP_MEMORY_LIMIT=256M
       # - PHP_MAIL=1 # Uncomment to enable mailhog.
-      - DOCKER_HOST_DOMAIN=${COMPOSE_PROJECT_NAME}.docker.localhost
+      - DOCKER_HOST_DOMAIN=${COMPOSE_DOMAIN}
     depends_on:
       - mariadb
     volumes:
@@ -31,6 +42,9 @@ services:
 
   nginx:
     image: nginx:latest
+    networks:
+      - app
+      - frontend
     depends_on:
       - phpfpm
     ports:
@@ -39,10 +53,14 @@ services:
       - ${PWD}/.docker/vhost.conf:/etc/nginx/conf.d/default.conf:ro
       - ./:/app:delegated
     labels:
-      - "traefik.http.routers.frontend.rule=Host(`${COMPOSE_PROJECT_NAME}.docker.localhost`)"
+      - "traefik.enable=true"
+      - "traefik.docker.network=frontend"
+      - "traefik.http.routers.frontend.rule=Host(`${${COMPOSE_DOMAIN}}`)"
 
   memcached:
     image: 'memcached:latest'
+    networks:
+      - app
     ports:
       - '11211'
     environment:
@@ -50,18 +68,11 @@ services:
 
   mailhog:
     image: mailhog/mailhog
+    networks:
+      - app
     ports:
       - "1025"
       - "8025"
-
-  reverse-proxy:
-    image: traefik:2.0  # The official Traefik docker image
-    command: --api.insecure=true --providers.docker # Enables the web UI and tells Traefik to listen to docker
-    ports:
-      - "80"
-      - "8080"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock  # So that Traefik can listen to the Docker events
 
 # Drush cache volume to persist cache between runs.
 volumes:

--- a/templates/symfony-4/docker-compose.yml
+++ b/templates/symfony-4/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
-      - "traefik.http.routers.${COMPOSE_DOMAIN}.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_DOMAIN}`)"
 
   memcached:
     image: 'memcached:latest'
@@ -73,7 +73,3 @@ services:
     ports:
       - "1025"
       - "8025"
-
-# Drush cache volume to persist cache between runs.
-volumes:
-  drush-cache:

--- a/templates/symfony-4/docker-compose.yml
+++ b/templates/symfony-4/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
-      - "traefik.http.routers.frontend.rule=Host(`${${COMPOSE_DOMAIN}}`)"
+      - "traefik.http.routers.${COMPOSE_DOMAIN}.rule=Host(`${${COMPOSE_DOMAIN}}`)"
 
   memcached:
     image: 'memcached:latest'

--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -1,0 +1,25 @@
+
+version: '3'
+
+networks:
+  frontend:
+    external: true
+    
+services:
+  traefik:
+    image: traefik:v2.0
+    container_name: traefik
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - frontend
+    ports:
+      - 80:80
+      - 8080:8080
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - $PWD/traefik.yml:/traefik.yml:ro
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.traefik.rule=Host(`traefik.docker.localhost`)"

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -1,0 +1,16 @@
+
+api:
+  dashboard: true
+  insecure: true
+  debug: true
+
+entryPoints:
+  http:
+    address: ":80"
+  https:
+    address: ":443"
+
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false


### PR DESCRIPTION
Ticket: https://jira.itkdev.dk/browse/TEAMMANAGE-1536

This will enable us to have a docker-compose setup with one træfik project as ingress and don't have to use port numbers and domain names will be free.

![Screenshot 2019-09-26 at 22 22 49](https://user-images.githubusercontent.com/111397/65722332-5bc2ca80-e0ac-11e9-9477-e465d5ba6bad.png)

@TODO: make the traefik containers start automatically